### PR TITLE
Fix for facebook streams freezing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "webpack",
     "start": "npm run build -- --display=errors-only && electron dist",
+    "start-local": "npm run build -- --display=errors-only && electron dist --webserver=http://localhost:4444 --username=woke --password=woke",
     "test": "jest"
   },
   "author": "Max Goodhart <c@chromakode.com>",

--- a/src/node/viewStateMachine.js
+++ b/src/node/viewStateMachine.js
@@ -198,7 +198,7 @@ const viewStateMachine = Machine(
             setInterval(() => video.play(), 1000)
 
             // Prevent sites from re-muting the video (Periscope, I'm looking at you!)
-            Object.defineProperty(video, 'muted', {writable: false, value: false})
+            Object.defineProperty(video, 'muted', {writable: true, value: false})
 
             const info = { title: document.title }
             let divBase = document.querySelector('div.BaseVideo') // This will filter for only periscope videos


### PR DESCRIPTION
- Fix for facebook streams freezing - see: https://github.com/chromakode/streamwall/issues/1
- New command: npm run start-local

